### PR TITLE
feat: separate encoded tx input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,24 @@ This utility allows to quickly online or offline a participation key, especially
 ### Installation
 
 ```bash
-go install github.com/algonode/algourl@latest
+go install github.com/algorandfoundation/algourl@latest
 ```
 
 The `algourl` binary will be available (in most cases) @ `~/go/bin/algourl`
 
-### Online an account with Mobile wallet 
+### Online an account with Mobile wallet
 
 ⚠️ Make sure the participation key is generated and imported (see full examples)
 </br>ℹ You do not need new key in case your online status got suspended for not voting.
 
 ```bash
-goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM -t - | ~/go/bin/algourl 
+goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM -t - | ~/go/bin/algourl
 ```
 
-### Offline an account with Mobile wallet 
+### Offline an account with Mobile wallet
+
 ```bash
-goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM --online=0 -t - | ~/go/bin/algourl 
+goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM --online=0 -t - | ~/go/bin/algourl
 ```
 
 ## Installation (full)
@@ -35,15 +36,13 @@ goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PX
 ### New participation key
 
 Initial state:
-* No active participation key for the account on the node
-* Account has some non zero balance (even 0.05 Algo is OK)
-* Account private keys **are not** stored on the node (GOOD!)
-* SSH access to the node :) 
 
+- No active participation key for the account on the node
+- Account has some non zero balance (even 0.05 Algo is OK)
+- Account private keys **are not** stored on the node (GOOD!)
+- SSH access to the node :)
 
 #### Let's generate new participation keys bundle for an account
-
-
 
 ```bash
 # goal account addpartkey --address=7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM --roundFirstValid=36876865 --roundLastValid=36976865
@@ -51,12 +50,11 @@ Please stand by while generating keys. This might take a few minutes...
 Participation key generation successful. Participation ID: TB3UFX2DUXSA7W7CDMWRAR4QJRALTXLGA54NPI2SIGD63XPJXX6A
 ```
 
-
 ## Example output
 
 ```bash
 
-#> goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM --online=0 -t - | algourl 
+#> goal account changeonlinestatus -a 7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM --online=0 -t - | algourl
 
 Paste below URL into your browser or scan QR code to online/offline the account
 algorand://7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM?type=keyreg&votefst=0&votelst=0
@@ -86,22 +84,20 @@ algorand://7THLM2QWR2VOGCLIQGGASSTHV6GBZAB2OMYRCDEQ2K5PXP42YKIAUKLOHM?type=keyre
 
 ```
 
-
-## TXN type support 
+## TXN type support
 
 `algourl` utility supports the following transactions
 
-- only participation key registration/deregistration transactions 
+- only participation key registration/deregistration transactions
 - unsigned raw MSGPack encoded files only
 
 ## Ecosystem support
 
-> Generated URLs/QRs are ARC-0026 backward compatible but new standard that allows for non-pay transactions is  yet to be published
+> Generated URLs/QRs are ARC-0026 backward compatible but new standard that allows for non-pay transactions is yet to be published
 
-|Wallet|TX Support|Remarks|
-|---|---|---|
-|[Defly mobile](https://defly.app/)| KEYREG, PAY| |
-
+| Wallet                             | TX Support  | Remarks |
+| ---------------------------------- | ----------- | ------- |
+| [Defly mobile](https://defly.app/) | KEYREG, PAY |         |
 
 # FAQ
 

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -17,8 +17,8 @@ type AUrlTxn struct {
 }
 
 type AUrlTxnKeyCommon struct {
-	Sender string `url:"-"`
-	Type   string `url:"type"`
+	Sender string  `url:"-"`
+	Type   string  `url:"type"`
 	Fee    *uint64 `url:"fee,omitempty"`
 }
 
@@ -54,7 +54,7 @@ type RawTxn struct {
 	Txn types.Transaction `codec:"txn"`
 }
 
-func MakeQRKeyRegRequest(encodedTxn []byte) (*AUrlTxn, error) {
+func MakeQRKeyRegRequestEncodedTxn(encodedTxn []byte) (*AUrlTxn, error) {
 	var txn RawTxn
 
 	msgpack.Decode(encodedTxn, &txn)
@@ -62,6 +62,10 @@ func MakeQRKeyRegRequest(encodedTxn []byte) (*AUrlTxn, error) {
 		return nil, fmt.Errorf("no support for transaction of type '%s'", txn.Txn.Type)
 	}
 
+	return MakeQRKeyRegRequest(txn)
+}
+
+func MakeQRKeyRegRequest(txn RawTxn) (*AUrlTxn, error) {
 	kr := &AUrlTxn{
 		AUrlTxnKeyCommon: AUrlTxnKeyCommon{
 			Sender: txn.Txn.Sender.String(),
@@ -77,7 +81,7 @@ func MakeQRKeyRegRequest(encodedTxn []byte) (*AUrlTxn, error) {
 		},
 	}
 	if uint64(txn.Txn.Fee) != uint64(1000) {
-		kr.AUrlTxnKeyCommon.Fee =	toPtr(uint64(txn.Txn.Fee))
+		kr.AUrlTxnKeyCommon.Fee = toPtr(uint64(txn.Txn.Fee))
 	}
 
 	return kr, nil

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/algonode/algourl
+module github.com/algorandfoundation/algourl
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/algonode/algourl/encoder"
+	"github.com/algorandfoundation/algourl/encoder"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func makeQRFromStdin() error {
 		return err
 	}
 
-	kr, err := encoder.MakeQRKeyRegRequest(encodedTxn)
+	kr, err := encoder.MakeQRKeyRegRequestEncodedTxn(encodedTxn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Separates the encoded tx input so that MakeQRKeyRegRequest can accept a transaction raw directly